### PR TITLE
gopher-net/ovs-plugin:latest not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ docker-machine ssh default "sudo modprobe openvswitch"
 
 ```yaml
 plugin:
-  image: gopher-net/ovs-plugin
+  image: gophernet/ovs-plugin
   volumes:
     - /run/docker/plugins:/run/docker/plugins
     - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 plugin:
-  image: gopher-net/ovs-plugin
+  image: gophernet/ovs-plugin
   volumes:
     - /run/docker/plugins:/run/docker/plugins
     - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
I tried to run the installation and got this message:

```
sudo ./install.sh 
Starting dockerovsplugin_ovs_1
Pulling plugin (gopher-net/ovs-plugin:latest)...
Pulling repository docker.io/gopher-net/ovs-plugin
ERROR: Error: image gopher-net/ovs-plugin:latest not found
```

The good repository is:

```
docker.io/gophernet/ovs-plugin 
```